### PR TITLE
fix bannerView's height

### DIFF
--- a/EBBannerView/Classes/EBBannerView.m
+++ b/EBBannerView/Classes/EBBannerView.m
@@ -237,7 +237,7 @@ static EBBannerWindow *sharedWindow;
 -(CGFloat)calculatedContentHeight{
     CGSize size = CGSizeMake(self.contentLabel.frame.size.width, MAXFLOAT);
     NSDictionary *dict = [NSDictionary dictionaryWithObject:[UIFont systemFontOfSize:self.contentLabel.font.pointSize] forKey:NSFontAttributeName];
-    CGFloat calculatedHeight = [self.contentLabel.text boundingRectWithSize:size options:NSStringDrawingUsesLineFragmentOrigin attributes:dict context:nil].size.height;
+    CGFloat calculatedHeight = ceil([self.contentLabel.text boundingRectWithSize:size options:NSStringDrawingUsesLineFragmentOrigin attributes:dict context:nil].size.height);
     return calculatedHeight;
 }
 


### PR DESCRIPTION
When the text reaches two lines, it needs to show the whole content. When the text exceeds three lines, activate the drop-down gesture.
So the function -(CGFloat)calculatedContentHeight{} that return bannerView's height should use ceil().
