### PR TITLE
crash on iOS 13 with swift application. 

### DIFF
--- a/EBBannerView/SwiftClasses/EBSystemBannerView.swift
+++ b/EBBannerView/SwiftClasses/EBSystemBannerView.swift
@@ -58,7 +58,7 @@ extension EBSystemBannerView {
         let size = CGSize(width: contentLabel.frame.size.width, height: CGFloat.greatestFiniteMagnitude)
         let text = contentLabel.text ?? ""
         let str = text as NSString
-        let calculatedHeight = str.boundingRect(with: size, options: .usesLineFragmentOrigin, attributes: [.font : contentLabel.font.pointSize], context: nil).size.height
+        let calculatedHeight = str.boundingRect(with: size, options: .usesLineFragmentOrigin, attributes: [.font : contentLabel.font!], context: nil).size.height
         return calculatedHeight
     }
 


### PR DESCRIPTION
The attribute font of bondingRect must be a font name and not a number.
With a number the application crash with [__NSCFNumber renderingMode]: unrecognized selector sent to instance ....